### PR TITLE
Coap proto updates

### DIFF
--- a/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/adaptors/CoapAdaptorUtils.java
+++ b/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/adaptors/CoapAdaptorUtils.java
@@ -60,7 +60,7 @@ public class CoapAdaptorUtils {
         return result.build();
     }
 
-    private static Set<String> toKeys(List<String> queryElements, String ...attributeNames) throws AdaptorException {
+    private static Set<String> toKeys(List<String> queryElements, String ...attributeNames) {
         String keys = null;
         for (String queryElement : queryElements) {
             String[] queryItem = queryElement.split("=", 2);

--- a/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/adaptors/CoapAdaptorUtils.java
+++ b/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/adaptors/CoapAdaptorUtils.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.transport.coap.adaptors;
 
+import com.google.gson.JsonElement;
 import org.eclipse.californium.core.coap.Request;
 import org.springframework.util.StringUtils;
 import org.thingsboard.server.common.transport.adaptor.AdaptorException;
@@ -26,6 +27,21 @@ import java.util.List;
 import java.util.Set;
 
 public class CoapAdaptorUtils {
+
+    /**
+     * If the json object has only one key of type array which is called "telemetry" then use the array as the root
+     * element and drop the surrounding container. This will allow multiple updates in one request just like in the
+     * pure json device api.
+     */
+    public static JsonElement convertProtoJsonTelemetry(JsonElement json) throws AdaptorException {
+        if (json.isJsonObject()) {
+            var root = json.getAsJsonObject();
+            if (root.has("telemetry") && root.get("telemetry").isJsonArray() && root.entrySet().size() == 1) {
+                return root.get("telemetry");
+            }
+        }
+        return json;
+    }
 
     public static TransportProtos.GetAttributeRequestMsg toGetAttributeRequestMsg(Request inbound) throws AdaptorException {
         List<String> queryElements = inbound.getOptions().getUriQuery();

--- a/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/adaptors/ProtoCoapAdaptor.java
+++ b/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/adaptors/ProtoCoapAdaptor.java
@@ -46,7 +46,8 @@ public class ProtoCoapAdaptor implements CoapTransportAdaptor {
     public TransportProtos.PostTelemetryMsg convertToPostTelemetry(UUID sessionId, Request inbound, Descriptors.Descriptor telemetryMsgDescriptor) throws AdaptorException {
         ProtoConverter.validateDescriptor(telemetryMsgDescriptor);
         try {
-            return JsonConverter.convertToTelemetryProto(new JsonParser().parse(ProtoConverter.dynamicMsgToJson(inbound.getPayload(), telemetryMsgDescriptor)));
+            var jsonMessage = new JsonParser().parse(ProtoConverter.dynamicMsgToJson(inbound.getPayload(), telemetryMsgDescriptor));
+            return JsonConverter.convertToTelemetryProto(CoapAdaptorUtils.convertProtoJsonTelemetry(jsonMessage));
         } catch (Exception e) {
             throw new AdaptorException(e);
         }

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/adaptor/JsonConverter.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/adaptor/JsonConverter.java
@@ -555,9 +555,9 @@ public class JsonConverter {
         }
     }
 
-    private static void addEntries(Map<Long, List<KvEntry>> result, long systemTs, JsonObject jo) {
+    private static void addEntries(Map<Long, List<KvEntry>> result, long ts, JsonObject jo) {
         for (KvEntry entry : parseValues(jo)) {
-            result.computeIfAbsent(systemTs, tmp -> new ArrayList<>()).add(entry);
+            result.computeIfAbsent(ts, tmp -> new ArrayList<>()).add(entry);
         }
     }
 


### PR DESCRIPTION
- allow multiple telemetry updates in a single CoAP request by unwrapping a "telemetry" array in the root message
  - this is the same feature that the json device api supports by sending an array as the root element instead of an object
- use the system timestamp when receiving telemetry with a timestamp of zero
  - this also affects the json device api
  - fixes #3 
- minor refactoring in the `JsonConverter`