### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Free up some disk space on the Github runner
+        run: du -hs /opt/hostedtoolcache; rm -rf /opt/hostedtoolcache
+
       - name: Checkout repository
         uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Free up some disk space on the Github runner
+        run: du -hs /opt/hostedtoolcache; rm -rf /opt/hostedtoolcache
+
       - name: Checkout repository
         uses: actions/checkout@v2
 


### PR DESCRIPTION
The default Github Action Runner is running out of disk space while building the Docker images:
> no space left on device

Source for this fix: https://github.com/orgs/community/discussions/25678#discussioncomment-5242449