### PR TITLE
fix release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Free up some disk space on the Github runner
+        run: du -hs /opt/hostedtoolcache; rm -rf /opt/hostedtoolcache
+
       - name: Checkout repository
         uses: actions/checkout@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
         run: du -hs /opt/hostedtoolcache; rm -rf /opt/hostedtoolcache
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3.0.0
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'zulu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,16 +20,16 @@ jobs:
         run: du -hs /opt/hostedtoolcache; rm -rf /opt/hostedtoolcache
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3.0.0
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'zulu'
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{env.DOCKER_REGISTRY}}
           username: ${{github.actor}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Free up some disk space on the Github runner
+        run: du -hs /opt/hostedtoolcache; rm -rf /opt/hostedtoolcache
+
       - name: Checkout repository
         uses: actions/checkout@v2
 


### PR DESCRIPTION
- free up disk space on the default GitHub Runner, because it was running out of space while building Docker images
- fix deprecation warnings because of outdated actions in the workflows